### PR TITLE
docs: define alpha error model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Project that aims to be a place where humans and AI can share their brains.
 
 - [Alpha model](docs/alpha-model.md)
 - [Alpha API contract](docs/alpha-api-contract.md)
+- [Alpha error model](docs/alpha-error-model.md)

--- a/docs/alpha-api-contract.md
+++ b/docs/alpha-api-contract.md
@@ -6,6 +6,8 @@ It is intentionally narrower than the eventual platform. The alpha is a
 note-first memory API for agents. It does not expose revision edges, graph
 internals, or conversational session state.
 
+See also: [Alpha error model](./alpha-error-model.md)
+
 ## Contract Rules
 
 - The API is stateless with respect to chat/session context.
@@ -331,6 +333,7 @@ Rules:
 
 ## Version And Error Semantics
 
+- responses should expose `X-Mnemosyne-Schema-Version: 0.1.0-alpha`
 - `version` is the client-facing optimistic concurrency field.
 - Stale `version` values return `409 Conflict`.
 - Missing notes return `404 Not Found`.

--- a/docs/alpha-api-contract.md
+++ b/docs/alpha-api-contract.md
@@ -14,12 +14,12 @@ See also: [Alpha error model](./alpha-error-model.md)
 - Clients own note targeting and short-lived conversational context.
 - The API exposes stable `note_id` and integer `version`, not revision graph
   mechanics.
-- `PUT` creates a fully specified new version and does not inherit prior note
-  content or context.
 - `PATCH` derives a new version from the latest note state and merges
   `add_about` deterministically.
 - Search operates on the latest visible note state only.
 - Context responses are note-centric JSON, not graph-shaped storage leaks.
+- Alpha uses `PATCH` as the only update operation. Full-replacement `PUT`
+  semantics are deferred.
 
 ## Endpoint Flow
 
@@ -242,42 +242,6 @@ Response:
 - `404 Not Found`
 - body: `ErrorResponse`
 
-### `PUT /notes/{note_id}`
-
-Creates a fully specified new note version.
-
-Request body:
-
-```json
-{
-  "content": "Need to pick up my blue shirt on Saturday.",
-  "about": [
-    {
-      "kind": "item",
-      "ref": {
-        "collection": "item",
-        "key": "item_shirt_001"
-      }
-    }
-  ],
-  "observed_at": "2026-04-06T18:00:00Z",
-  "version": 1
-}
-```
-
-Response:
-- `200 OK`
-- body: `NoteView`
-- `404 Not Found`
-- body: `ErrorResponse`
-- `409 Conflict`
-- body: `ErrorResponse`
-
-Rules:
-- creates a new version of the same logical note
-- requires the expected latest `version` for optimistic concurrency
-- does not inherit prior content or prior `about` context implicitly
-
 ### `PATCH /notes/{note_id}`
 
 Creates a derived new note version from the latest visible note.
@@ -312,6 +276,9 @@ Rules:
 - derives from the latest visible note
 - appends structured addendum content rather than replacing content wholesale
 - merges `add_about` into the new version with deterministic dedupe
+- if `observed_at` is omitted, the latest revision value is retained
+- if `observed_at` is provided, it replaces the latest revision value in the
+  new revision
 - fails if no patch operation was requested
 
 ### `GET /notes/{note_id}/context`
@@ -328,17 +295,23 @@ Rules:
 - note-centric response, not raw graph/path output
 - related notes are returned as ranked latest-note summaries
 - context basis is explicit: resolved and pending about values used for context
+- related notes are selected by:
+  - shared resolved `about` refs, and
+  - normalized pending labels matched case-insensitively
+- the anchor note itself is excluded
+- ranking is overlap count first, recency second
+- alpha should cap related notes to a small list such as `5`
 - this contract is defined now for alpha retrieval work, even if implementation
   lands later than the write/search endpoints
 
 ## Version And Error Semantics
 
-- responses should expose `X-Mnemosyne-Schema-Version: 0.1.0-alpha`
 - `version` is the client-facing optimistic concurrency field.
 - Stale `version` values return `409 Conflict`.
 - Missing notes return `404 Not Found`.
 - Semantically invalid patch requests return `400 Bad Request`.
 - Error payloads use the shared `ErrorResponse` shape across note endpoints.
+- Schema-version signaling is deferred for alpha and documented separately.
 
 ## Explicit Non-Goals For Alpha
 
@@ -346,3 +319,4 @@ Rules:
 - exposing raw Arango documents or graph edge names
 - conversational/session-state interpretation inside the API runtime
 - first-class entity/relationship/event/reminder write APIs
+- full-replacement `PUT /notes/{note_id}` semantics

--- a/docs/alpha-error-model.md
+++ b/docs/alpha-error-model.md
@@ -1,0 +1,128 @@
+# Mnemosyne Alpha Error Model And Schema Versioning
+
+This document defines the shared error payload and the schema-version signaling
+rules for `0.1.0-alpha`.
+
+See also: [Alpha API contract](./alpha-api-contract.md)
+
+## Decision
+
+For alpha, Mnemosyne uses:
+
+- one shared JSON error shape across note endpoints
+- one explicit response header for schema-version signaling
+- stable public error codes that do not leak DB or graph internals
+
+That is enough for alpha. Anything more elaborate is ceremony.
+
+## Shared Error Shape
+
+All application-level error responses should converge on this payload:
+
+```json
+{
+  "error": "version_conflict",
+  "details": [
+    {
+      "field": "version",
+      "message": "Version does not match latest note version.",
+      "code": "version_conflict",
+      "context": {
+        "note_id": "note_001",
+        "current_version": 2,
+        "requested_version": 1
+      }
+    }
+  ],
+  "request_id": null
+}
+```
+
+Top-level fields:
+
+- `error`: stable high-level error identifier
+- `details`: structured detail entries
+- `request_id`: optional correlation id for logs and tracing
+
+Detail fields:
+
+- `field`: optional field or parameter reference
+- `message`: human-readable explanation
+- `code`: stable machine-readable detail code
+- `context`: optional structured metadata
+
+## Error Flow
+
+```mermaid
+flowchart TD
+    A[Client request] --> B{Valid request?}
+    B -- no --> C[400 ErrorResponse]
+    B -- yes --> D{Latest version matches?}
+    D -- no --> E[409 ErrorResponse]
+    D -- yes --> F{Target note exists?}
+    F -- no --> G[404 ErrorResponse]
+    F -- yes --> H[2xx success response]
+```
+
+## Alpha Error Catalog
+
+The exact catalog can grow, but alpha should at least reserve these stable
+top-level identifiers:
+
+- `validation_error`
+- `invalid_note_patch`
+- `note_not_found`
+- `version_conflict`
+- `internal_error`
+
+Detail `code` values may be narrower, but should remain aligned with the same
+public vocabulary.
+
+## Public Naming Rules
+
+- error names must describe API behavior, not storage internals
+- do not expose collection names, edge names, AQL terms, or Arango-specific
+  implementation details in `error` or `code`
+- `note_not_found` is acceptable
+- `latest_revision_edge_missing` is not
+
+## Schema Version Signaling
+
+Alpha uses one response header:
+
+```http
+X-Mnemosyne-Schema-Version: 0.1.0-alpha
+```
+
+Rules:
+
+- success and error responses should expose the same schema version header
+- payload bodies do not need an extra `schema_version` field in alpha
+- the public contract version is signaled at the HTTP layer, not by leaking
+  storage revision ids
+- breaking API contract changes require a schema-version bump and updated docs
+
+## Version Semantics
+
+Do not conflate schema version with note version.
+
+- `X-Mnemosyne-Schema-Version` describes the public API contract version
+- `version` inside note payloads describes optimistic concurrency for one note
+
+Those are different things and should stay different.
+
+## Current Alpha Scope
+
+For `0.1.0-alpha`, the required guarantees are:
+
+- `400`, `404`, and `409` use the shared `ErrorResponse` shape
+- note writes and reads use stable public error names
+- schema-version signaling exists and is explicit
+- public docs refer to public API terms, not DB internals
+
+## Deferred
+
+- path or media-type versioning
+- multi-schema negotiation
+- endpoint-specific error envelopes
+- graph/path-specific error formats

--- a/docs/alpha-error-model.md
+++ b/docs/alpha-error-model.md
@@ -1,7 +1,7 @@
 # Mnemosyne Alpha Error Model And Schema Versioning
 
-This document defines the shared error payload and the schema-version signaling
-rules for `0.1.0-alpha`.
+This document defines the shared error payload for `0.1.0-alpha` and records
+what is explicitly deferred.
 
 See also: [Alpha API contract](./alpha-api-contract.md)
 
@@ -10,8 +10,8 @@ See also: [Alpha API contract](./alpha-api-contract.md)
 For alpha, Mnemosyne uses:
 
 - one shared JSON error shape across note endpoints
-- one explicit response header for schema-version signaling
-- stable public error codes that do not leak DB or graph internals
+- a minimal set of stable public error names that do not leak DB or graph
+  internals
 
 That is enough for alpha. Anything more elaborate is ceremony.
 
@@ -64,19 +64,15 @@ flowchart TD
     F -- yes --> H[2xx success response]
 ```
 
-## Alpha Error Catalog
+## Current Alpha Errors
 
-The exact catalog can grow, but alpha should at least reserve these stable
-top-level identifiers:
+Alpha only needs the errors already implied by the current write/read surface:
 
-- `validation_error`
 - `invalid_note_patch`
 - `note_not_found`
 - `version_conflict`
-- `internal_error`
 
-Detail `code` values may be narrower, but should remain aligned with the same
-public vocabulary.
+Anything broader can wait until the API surface is larger.
 
 ## Public Naming Rules
 
@@ -86,27 +82,11 @@ public vocabulary.
 - `note_not_found` is acceptable
 - `latest_revision_edge_missing` is not
 
-## Schema Version Signaling
-
-Alpha uses one response header:
-
-```http
-X-Mnemosyne-Schema-Version: 0.1.0-alpha
-```
-
-Rules:
-
-- success and error responses should expose the same schema version header
-- payload bodies do not need an extra `schema_version` field in alpha
-- the public contract version is signaled at the HTTP layer, not by leaking
-  storage revision ids
-- breaking API contract changes require a schema-version bump and updated docs
-
 ## Version Semantics
 
-Do not conflate schema version with note version.
+Do not conflate API contract version with note version.
 
-- `X-Mnemosyne-Schema-Version` describes the public API contract version
+- the public API contract is currently documented, not header-versioned
 - `version` inside note payloads describes optimistic concurrency for one note
 
 Those are different things and should stay different.
@@ -117,11 +97,11 @@ For `0.1.0-alpha`, the required guarantees are:
 
 - `400`, `404`, and `409` use the shared `ErrorResponse` shape
 - note writes and reads use stable public error names
-- schema-version signaling exists and is explicit
 - public docs refer to public API terms, not DB internals
 
 ## Deferred
 
+- schema-version signaling headers
 - path or media-type versioning
 - multi-schema negotiation
 - endpoint-specific error envelopes

--- a/docs/alpha-model.md
+++ b/docs/alpha-model.md
@@ -24,7 +24,7 @@ classDiagram
     }
 
     class AboutRef {
-      +kind: person|place|item|topic|other
+      +kind: person|location|item|topic|other
       +ref?: object
       +label?: string
     }
@@ -71,6 +71,20 @@ flowchart TD
 - Previous revisions are retained.
 - Normal reads return the latest note snapshot.
 - Unresolved references stay unresolved as labels until a later explicit resolution step exists.
+
+## `about.kind` Vocabulary
+
+Alpha keeps the public `kind` vocabulary intentionally small:
+
+- `person`
+- `location`
+- `item`
+- `topic`
+- `other`
+
+`topic` is not a free-form tag system. It means the note is explicitly about a
+subject area or discussion topic the writer wants to preserve as note context.
+If it starts behaving like arbitrary label spam, the model has failed.
 
 ## Explicitly Out Of Scope For Alpha
 


### PR DESCRIPTION
## Summary
- add a dedicated alpha error-model doc
- trim the alpha contract to the actual MVP error surface
- narrow update semantics to PATCH-only for alpha and lock the small about.kind vocabulary

## Context
- aligns the repo docs with issue #13
- removes premature schema-version header and broad error-catalog commitments
- keeps the alpha contract honest and implementable

## Testing
- not run (documentation only)