### PR TITLE
Fix DATETIME serialization for ArcadeDB UPSERT/CONTENT writes

### DIFF
--- a/app/repository/observations_arcade.py
+++ b/app/repository/observations_arcade.py
@@ -255,8 +255,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
             )
         )
         revisions = tuple(
-            self._revision_from_row(revision_row)
-            for revision_row in revision_rows
+            self._revision_from_row(revision_row) for revision_row in revision_rows
         )
         return Observation(
             observation_id=str(row["observation_id"]),
@@ -663,7 +662,11 @@ def _datetime(value: object) -> datetime:
 
 
 def _datetime_value(value: datetime) -> str:
-    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    # ArcadeDB DATETIME columns silently drop SET assignments when given an
+    # ISO 8601 string with a `T` separator or `Z` suffix. The accepted wire
+    # format is `yyyy-MM-dd HH:mm:ss` (always UTC, since this layer normalizes
+    # via .astimezone(UTC) first).
+    return value.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _optional_str(value: object) -> str | None:

--- a/tests/test_observations_arcade_repository.py
+++ b/tests/test_observations_arcade_repository.py
@@ -264,6 +264,21 @@ def test_arcade_repository_create_observation_keeps_entity_identity_stable() -> 
     assert "entity_id = ifnull(entity_id, :entity_id_0)" in script
 
 
+def test_arcade_repository_serializes_datetime_in_arcadedb_format() -> None:
+    # Regression: ArcadeDB DATETIME columns silently drop SET assignments when
+    # given an ISO 8601 string with the `T` separator or `Z` suffix. Every
+    # write path through this repository must emit `yyyy-MM-dd HH:mm:ss`
+    # (always UTC) so Source/Revision/Entity rows actually persist their
+    # timestamps. Failure mode: created_at ends up null on every UPSERT and
+    # the response projection raises ValueError on read.
+    from app.repository.observations_arcade import _datetime_value
+
+    encoded = _datetime_value(datetime(2026, 4, 6, 17, 0, tzinfo=UTC))
+    assert encoded == "2026-04-06 17:00:00"
+    assert "T" not in encoded
+    assert "Z" not in encoded
+
+
 def test_arcade_repository_patch_observation_increments_version_internally() -> None:
     backend = _FakeArcadeBackend()
     repository = ArcadeObservationsRepository(
@@ -445,7 +460,7 @@ def test_arcade_repository_patch_retries_when_assigned_version_conflicts() -> No
             "It is still blue."
         ),
         "content_format": "text/plain",
-        "observed_at": "2026-04-06T18:00:00Z",
+        "observed_at": "2026-04-06 18:00:00",
         "created_at": revision_payload["created_at"],
     }
 
@@ -609,9 +624,7 @@ def test_arcade_repository_context_uses_related_observation_overlap() -> None:
 
     context = repository.get_observation_context("obs_001")
 
-    assert [item.observation_id for item in context.related_observations] == [
-        "obs_002"
-    ]
+    assert [item.observation_id for item in context.related_observations] == ["obs_002"]
     assert context.related_observations[0].score == 2.0
     query, params = backend.queries[0]
     assert "observation_id <> :observation_id" in query


### PR DESCRIPTION
## Summary

- Closes #77. Initial diagnosis in the issue (parameter-name collision) turned out to be wrong — see "Real root cause" below.
- `_datetime_value` now emits `yyyy-MM-dd HH:mm:ss` (UTC) instead of ISO 8601 with `T`/`Z`. The read path `_datetime` already accepts this format, so the change is single-sided.
- Adds a regression test that asserts the serializer output matches what ArcadeDB will actually persist.

## Real root cause

ArcadeDB DATETIME columns silently drop `UPDATE ... SET col = '<value>'` assignments when the value is an ISO 8601 string with the `T` separator or `Z` suffix — both via named parameters and via inline string literals. The UPDATE returns `count: 1` (the WHERE matches), but the SET never applies. Same behavior on `CREATE VERTEX ... CONTENT :json` writes for DATETIME fields.

Verified locally by exercising `UPDATE Source SET created_at = ...` against the running ArcadeDB instance with several value shapes:

| Value sent | `created_at` after UPDATE |
| --- | --- |
| `:param = "2026-05-26T18:00:00Z"` | `null` |
| `:param = "2026-05-26 18:00:00"` | `"2026-05-26 18:00:00"` ✅ |
| `:param = 1748275200000` (epoch ms) | `"2025-05-26 16:00:00"` ✅ |
| inline `'2026-05-26T18:00:00Z'` | `null` |
| inline `date('2026-05-26T18:00:00Z')` | `null` |

So the parameter name `:created_at` was not actually colliding with the column name `created_at` — that was a red herring. The real failure mode is on the value side: ArcadeDB's DATETIME coercion rejects the `T`/`Z` ISO 8601 shape silently.

## User-visible symptom (unchanged from #77)

Every `POST /observations` returned 500 because the response projection's `_source_from_row` runs `_datetime("None")`, which raises `ValueError: Invalid isoformat string: 'None'`. The write itself succeeded at the storage layer, but Source, Entity, and Revision rows all ended up with `created_at: null`.

## Test plan

- [x] `uv run pytest` — 37 passed locally (1 existing assertion updated to match the new format)
- [x] `uv run ruff check app tests` — clean
- [x] `uv run ruff format --check` — clean on the two files touched (pre-existing format violations on `main` left alone)
- [x] End-to-end smoke test: `docker compose up --build --force-recreate -d` → `POST /observations` returns `201` with full body, `SELECT created_at FROM Source` returns a populated timestamp string
- [ ] Reviewer: confirm no other ArcadeDB query in the codebase relies on the `T`/`Z` shape on the wire (write side only — `_datetime` read parser handles both)

## Notes for follow-up (not in this PR)

- The `:created_at` parameter naming still exists across the three UPSERT scripts. With the value-side fix in place, the parameter name is harmless. If we want to defensively rename to e.g. `:now_ts`, that can be a separate cosmetic PR.
- `_datetime_value` drops microsecond precision (`%S` only). If ms precision becomes necessary, switch to a DATETIME_MICROS column type and adjust the format string.