### PR TITLE
Document search scoring and updated_at ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,18 @@ curl -sS -X PATCH http://127.0.0.1:8180/observations/obs_... \
   -H 'Content-Type: application/json' \
   -d '{"addendum": "It is the Oxford shirt."}'
 ```
+
+Search current observation revisions:
+
+```shell
+curl -sS 'http://127.0.0.1:8180/observations?q=blue%20shirt&limit=5'
+```
+
+Search ranking is lexical-only in the current alpha. The server strips and
+casefolds `q`, matches it against each observation's latest revision content,
+and returns only matches with `score > 0`. A full-query substring match scores
+`1.0`; otherwise the score is the fraction of whitespace-separated query terms
+present in the content. Results sort by `score`, then `observed_at`, then `id`,
+all descending. Scores are relative to one query result set, not calibrated
+across different queries. Stemming, BM25/TF-IDF, embeddings, and hybrid
+reranking are not active yet; stronger indexes are planned.

--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ Search current observation revisions:
 curl -sS 'http://127.0.0.1:8180/observations?q=blue%20shirt&limit=5'
 ```
 
-Search ranking is lexical-only in the current alpha. The server strips and
+Search scoring is lexical-only in the current alpha. The server strips and
 casefolds `q`, matches it against each observation's latest revision content,
 and returns only matches with `score > 0`. A full-query substring match scores
 `1.0`; otherwise the score is the fraction of whitespace-separated query terms
-present in the content. Results sort by `score`, then `observed_at`, then `id`,
-all descending. Scores are relative to one query result set, not calibrated
-across different queries. Stemming, BM25/TF-IDF, embeddings, and hybrid
-reranking are not active yet; stronger indexes are planned.
+present in the content. Results sort by observation `updated_at`, then `id`,
+both descending; `score` does not override recency ordering. Scores are relative
+to one query result set, not calibrated across different queries. Stemming,
+BM25/TF-IDF, embeddings, and hybrid reranking are not active yet; stronger
+indexes are planned.

--- a/app/main.py
+++ b/app/main.py
@@ -145,14 +145,14 @@ def create_app() -> FastAPI:
         q: str = "",
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        """Search current observation revisions with lexical ranking.
+        """Search current observation revisions with lexical scoring.
 
         `q` is stripped and casefolded, then matched against the casefolded
         latest revision content. A full-query substring match scores `1.0`;
         otherwise the query is split on whitespace and the score is the
         fraction of query terms present in the content. Results with score
-        `0` are omitted and matches sort by score, `observed_at`, then `id`,
-        all descending. Scores are query-relative, not globally calibrated.
+        `0` are omitted and matches sort by `updated_at` descending. Scores are
+        query-relative, not globally calibrated.
         """
         if not q.strip():
             raise InvalidObservationRequestError(
@@ -582,6 +582,7 @@ def _serialize_search_result(result: ObservationSearchResult) -> dict[str, Any]:
         "version": result.version,
         "content_preview": result.content_preview,
         "observed_at": _format_datetime(result.observed_at),
+        "updated_at": _format_datetime(result.updated_at),
         "score": result.score,
     }
 

--- a/app/main.py
+++ b/app/main.py
@@ -145,6 +145,15 @@ def create_app() -> FastAPI:
         q: str = "",
         limit: int = 5,
     ) -> list[dict[str, Any]]:
+        """Search current observation revisions with lexical ranking.
+
+        `q` is stripped and casefolded, then matched against the casefolded
+        latest revision content. A full-query substring match scores `1.0`;
+        otherwise the query is split on whitespace and the score is the
+        fraction of query terms present in the content. Results with score
+        `0` are omitted and matches sort by score, `observed_at`, then `id`,
+        all descending. Scores are query-relative, not globally calibrated.
+        """
         if not q.strip():
             raise InvalidObservationRequestError(
                 error="invalid_observation_request",

--- a/app/models/observations.py
+++ b/app/models/observations.py
@@ -170,6 +170,7 @@ class ObservationSearchResult:
     version: int
     content_preview: str
     observed_at: datetime
+    updated_at: datetime
     score: float
 
 

--- a/app/repository/observations_arcade.py
+++ b/app/repository/observations_arcade.py
@@ -104,6 +104,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
     ) -> tuple[ObservationSearchResult, ...]:
         result = self.runtime.query(
             "SELECT id, observation_type, "
+            "updated_at, "
             "out('CurrentRevision')[0].version AS version, "
             "out('CurrentRevision')[0].content AS content, "
             "out('CurrentRevision')[0].observed_at AS observed_at "
@@ -123,6 +124,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
                     version=int(row["version"]),
                     content_preview=content_preview(content),
                     observed_at=_datetime(row["observed_at"]),
+                    updated_at=_datetime(row["updated_at"]),
                     score=score,
                 )
             )
@@ -130,8 +132,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
             sorted(
                 matches,
                 key=lambda item: (
-                    item.score,
-                    item.observed_at.timestamp(),
+                    item.updated_at.timestamp(),
                     item.id,
                 ),
                 reverse=True,
@@ -183,6 +184,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
                     version=latest.version,
                     content_preview=content_preview(latest.content),
                     observed_at=latest.observed_at,
+                    updated_at=observation.updated_at,
                     score=1.0,
                 )
 
@@ -190,7 +192,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
             sorted(
                 matches.values(),
                 key=lambda item: (
-                    item.observed_at.timestamp(),
+                    item.updated_at.timestamp(),
                     item.id,
                 ),
                 reverse=True,
@@ -278,6 +280,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
                     version=latest.version,
                     content_preview=content_preview(latest.content),
                     observed_at=latest.observed_at,
+                    updated_at=candidate.updated_at,
                     score=score,
                 )
             )
@@ -288,7 +291,7 @@ class ArcadeObservationsRepository(ObservationsRepository):
                     related,
                     key=lambda item: (
                         item.score,
-                        item.observed_at.timestamp(),
+                        item.updated_at.timestamp(),
                         item.id,
                     ),
                     reverse=True,

--- a/app/repository/observations_in_memory.py
+++ b/app/repository/observations_in_memory.py
@@ -118,6 +118,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
                     version=latest.version,
                     content_preview=content_preview(latest.content),
                     observed_at=latest.observed_at,
+                    updated_at=observation.updated_at,
                     score=score,
                 )
             )
@@ -126,8 +127,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
             sorted(
                 matches,
                 key=lambda item: (
-                    item.score,
-                    item.observed_at.timestamp(),
+                    item.updated_at.timestamp(),
                     item.id,
                 ),
                 reverse=True,
@@ -153,6 +153,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
                     version=latest.version,
                     content_preview=content_preview(latest.content),
                     observed_at=latest.observed_at,
+                    updated_at=observation.updated_at,
                     score=1.0,
                 )
             )
@@ -161,7 +162,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
             sorted(
                 matches,
                 key=lambda item: (
-                    item.observed_at.timestamp(),
+                    item.updated_at.timestamp(),
                     item.id,
                 ),
                 reverse=True,
@@ -231,6 +232,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
                     version=latest.version,
                     content_preview=content_preview(latest.content),
                     observed_at=latest.observed_at,
+                    updated_at=observation.updated_at,
                     score=score,
                 )
             )
@@ -242,7 +244,7 @@ class InMemoryObservationsRepository(ObservationsRepository):
                     related,
                     key=lambda item: (
                         item.score,
-                        item.observed_at.timestamp(),
+                        item.updated_at.timestamp(),
                         item.id,
                     ),
                     reverse=True,

--- a/docs/alpha-api-contract.md
+++ b/docs/alpha-api-contract.md
@@ -96,7 +96,7 @@ Response `201`:
 `GET /observations?q=shirt&limit=5`
 
 Search evaluates only the latest/current revision content for each observation.
-The current alpha ranking is lexical-only:
+The current alpha scoring model is lexical-only:
 
 - `q` is stripped and casefolded before matching.
 - Content is casefolded before matching.
@@ -104,12 +104,13 @@ The current alpha ranking is lexical-only:
 - Otherwise, the query is split on whitespace and `score` is the fraction of
   query terms that appear in the content.
 - Results with `score = 0` are omitted.
-- Returned results sort by `score`, then `observed_at`, then `id`, all
-  descending.
+- Returned results sort by observation `updated_at`, then `id`, both
+  descending. `score` is returned for lexical relevance insight, but it does
+  not override recency ordering.
 
 Scores are query-relative relevance signals in the range `(0, 1]` for returned
-rows. They are useful for ordering one result set, but are not globally
-calibrated across different queries. There is no stemming, BM25/TF-IDF,
+rows. They are useful inside one result set, but are not globally calibrated
+across different queries. There is no stemming, BM25/TF-IDF,
 embedding similarity, or hybrid reranking in the current implementation.
 Stronger indexes are planned; when semantic/vector or hybrid ranking lands,
 this contract should grow an explicit ranking mode and updated score semantics.
@@ -124,6 +125,7 @@ Response `200`:
     "version": 1,
     "content_preview": "My blue shirt is at John's place.",
     "observed_at": "2026-04-06T17:00:00Z",
+    "updated_at": "2026-04-06T17:00:00Z",
     "score": 1.0
   }
 ]
@@ -137,7 +139,8 @@ Returns recent current versions of note observations whose current revision
 mentions a topic matching `{topic}`. The topic path segment may be a full topic
 label or a partial substring, so `coding:fcrozetta:python` matches
 `coding:fcrozetta:python:coding-style` and
-`coding:fcrozetta:python:linting`.
+`coding:fcrozetta:python:linting`. Results sort by observation `updated_at`,
+then `id`, both descending.
 
 Response `200`:
 
@@ -149,6 +152,7 @@ Response `200`:
     "version": 2,
     "content_preview": "Prefer pathlib for local file handling.",
     "observed_at": "2026-04-08T10:00:00Z",
+    "updated_at": "2026-04-08T10:30:00Z",
     "score": 1.0
   }
 ]

--- a/docs/alpha-api-contract.md
+++ b/docs/alpha-api-contract.md
@@ -95,6 +95,25 @@ Response `201`:
 
 `GET /observations?q=shirt&limit=5`
 
+Search evaluates only the latest/current revision content for each observation.
+The current alpha ranking is lexical-only:
+
+- `q` is stripped and casefolded before matching.
+- Content is casefolded before matching.
+- If the full normalized query is a substring of the content, `score` is `1.0`.
+- Otherwise, the query is split on whitespace and `score` is the fraction of
+  query terms that appear in the content.
+- Results with `score = 0` are omitted.
+- Returned results sort by `score`, then `observed_at`, then `id`, all
+  descending.
+
+Scores are query-relative relevance signals in the range `(0, 1]` for returned
+rows. They are useful for ordering one result set, but are not globally
+calibrated across different queries. There is no stemming, BM25/TF-IDF,
+embedding similarity, or hybrid reranking in the current implementation.
+Stronger indexes are planned; when semantic/vector or hybrid ranking lands,
+this contract should grow an explicit ranking mode and updated score semantics.
+
 Response `200`:
 
 ```json

--- a/tests/test_observations_api.py
+++ b/tests/test_observations_api.py
@@ -165,7 +165,7 @@ def test_observations_support_topic_strings_and_recent_topic_lookup(
         f"/observations/{second.json()['id']}",
         json={
             "addendum": "This is the current version.",
-            "observed_at": "2026-04-08T10:00:00Z",
+            "observed_at": "2026-04-04T10:00:00Z",
         },
     )
     assert patched.status_code == 200
@@ -180,6 +180,10 @@ def test_observations_support_topic_strings_and_recent_topic_lookup(
         (second.json()["id"], 2),
         (first.json()["id"], 1),
     ]
+    assert [item["updated_at"] for item in recent.json()] == sorted(
+        [item["updated_at"] for item in recent.json()],
+        reverse=True,
+    )
 
     partial = client.get("/topics/coding-style/observations")
 
@@ -187,6 +191,55 @@ def test_observations_support_topic_strings_and_recent_topic_lookup(
     assert [(item["id"], item["version"]) for item in partial.json()] == [
         (first.json()["id"], 1)
     ]
+
+
+def test_observations_search_orders_by_updated_at_desc(monkeypatch) -> None:
+    monkeypatch.setenv("MNEMOSYNE_STORAGE_BACKEND", "in-memory")
+    client = _client()
+
+    older_higher_score = client.post(
+        "/observations",
+        json={
+            "type": "note",
+            "content": "Cerulean saxifrage marker is stored in the closet.",
+            "observed_at": "2026-04-10T10:00:00Z",
+        },
+    )
+    newer_lower_score = client.post(
+        "/observations",
+        json={
+            "type": "note",
+            "content": "Cerulean marker is in the laundry basket.",
+            "observed_at": "2026-04-05T10:00:00Z",
+        },
+    )
+    patched = client.patch(
+        f"/observations/{newer_lower_score.json()['id']}",
+        json={
+            "addendum": "Still cerulean.",
+            "observed_at": "2026-04-04T10:00:00Z",
+        },
+    )
+
+    assert older_higher_score.status_code == 201
+    assert newer_lower_score.status_code == 201
+    assert patched.status_code == 200
+
+    response = client.get(
+        "/observations",
+        params={"q": "cerulean saxifrage", "limit": 5},
+    )
+
+    assert response.status_code == 200
+    results = response.json()
+    assert [(item["id"], item["version"], item["score"]) for item in results] == [
+        (newer_lower_score.json()["id"], 2, 0.5),
+        (older_higher_score.json()["id"], 1, 1.0),
+    ]
+    assert [item["updated_at"] for item in results] == sorted(
+        [item["updated_at"] for item in results],
+        reverse=True,
+    )
 
 
 def test_observation_patch_rejects_empty_change(monkeypatch) -> None:
@@ -270,7 +323,7 @@ def test_notes_endpoint_is_not_part_of_the_alpha_observation_api(monkeypatch) ->
     assert response.status_code == 404
 
 
-def test_observations_search_openapi_documents_ranking_semantics() -> None:
+def test_observations_search_openapi_documents_scoring_semantics() -> None:
     client = _client()
 
     response = client.get("/openapi.json")
@@ -279,6 +332,7 @@ def test_observations_search_openapi_documents_ranking_semantics() -> None:
     description = response.json()["paths"]["/observations"]["get"][
         "description"
     ]
-    assert "lexical ranking" in description
+    assert "lexical scoring" in description
     assert "full-query substring match scores `1.0`" in description
-    assert "Scores are query-relative" in description
+    assert "matches sort by `updated_at` descending" in description
+    assert "query-relative" in description

--- a/tests/test_observations_api.py
+++ b/tests/test_observations_api.py
@@ -268,3 +268,17 @@ def test_notes_endpoint_is_not_part_of_the_alpha_observation_api(monkeypatch) ->
     response = client.post("/notes", json={"content": "legacy"})
 
     assert response.status_code == 404
+
+
+def test_observations_search_openapi_documents_ranking_semantics() -> None:
+    client = _client()
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    description = response.json()["paths"]["/observations"]["get"][
+        "description"
+    ]
+    assert "lexical ranking" in description
+    assert "full-query substring match scores `1.0`" in description
+    assert "Scores are query-relative" in description

--- a/tests/test_observations_arcade_repository.py
+++ b/tests/test_observations_arcade_repository.py
@@ -80,6 +80,7 @@ def test_arcade_repository_search_uses_current_revision_and_observation_type() -
                             "version": 2,
                             "content": "The blue shirt is at John's place.",
                             "observed_at": "2026-04-06T18:05:00Z",
+                            "updated_at": "2026-04-06T18:05:00Z",
                         }
                     ]
                 }
@@ -90,12 +91,14 @@ def test_arcade_repository_search_uses_current_revision_and_observation_type() -
                         "version": 1,
                         "content": "The blue shirt is missing.",
                         "observed_at": "2026-04-06T17:00:00Z",
+                        "updated_at": "2026-04-06T17:00:00Z",
                     },
                     {
                         "id": "obs_001",
                         "version": 2,
                         "content": "The blue shirt is at John's place.",
                         "observed_at": "2026-04-06T18:05:00Z",
+                        "updated_at": "2026-04-06T18:05:00Z",
                     },
                 ]
             }
@@ -138,6 +141,7 @@ def test_arcade_search_scores_loaded_current_revisions() -> None:
                         "version": 1,
                         "content": "Blue shirt is at John's place.",
                         "observed_at": "2026-04-06T17:00:00Z",
+                        "updated_at": "2026-04-06T17:00:00Z",
                     },
                     {
                         "id": "obs_002",
@@ -145,6 +149,7 @@ def test_arcade_search_scores_loaded_current_revisions() -> None:
                         "version": 1,
                         "content": "Blue mug is in the kitchen.",
                         "observed_at": "2026-04-06T18:00:00Z",
+                        "updated_at": "2026-04-07T18:00:00Z",
                     },
                 ]
             }
@@ -155,8 +160,8 @@ def test_arcade_search_scores_loaded_current_revisions() -> None:
     results = repository.search_observations("shirt blue", limit=5)
 
     assert [(item.id, item.score) for item in results] == [
-        ("obs_001", 1.0),
         ("obs_002", 0.5),
+        ("obs_001", 1.0),
     ]
     query, params = backend.queries[0]
     assert "LIKE" not in query
@@ -254,7 +259,7 @@ def test_arcade_recent_by_topic_uses_index_and_latest_notes() -> None:
                         "Addendum:\nThis is the current version."
                     ),
                     content_format="text/plain",
-                    observed_at=datetime(2026, 4, 8, 10, 0, tzinfo=UTC),
+                    observed_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
                     created_at=datetime(2026, 4, 8, 10, 0, tzinfo=UTC),
                     mentions=(lint_topic,),
                 ),

--- a/tests/test_observations_in_memory.py
+++ b/tests/test_observations_in_memory.py
@@ -109,6 +109,10 @@ def test_create_patch_search_and_context_flow() -> None:
         ("obs_001", 2, 1.0),
         ("obs_002", 1, 1.0),
     ]
+    assert [item.updated_at for item in search] == sorted(
+        [item.updated_at for item in search],
+        reverse=True,
+    )
 
     context = repository.get_observation_context("obs_001")
     assert context.observation.id == "obs_001"
@@ -171,7 +175,7 @@ def test_recent_by_topic_matches_partial_topic_and_latest_versions() -> None:
         second.id,
         PatchObservationInput(
             addendum="This is the current version.",
-            observed_at=datetime(2026, 4, 8, 10, 0, tzinfo=UTC),
+            observed_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
         ),
     )
 
@@ -184,6 +188,10 @@ def test_recent_by_topic_matches_partial_topic_and_latest_versions() -> None:
         (second.id, 2),
         (first.id, 1),
     ]
+    assert [item.updated_at for item in recent] == sorted(
+        [item.updated_at for item in recent],
+        reverse=True,
+    )
 
     partial = repository.recent_observations_by_topic("coding-style", limit=5)
 


### PR DESCRIPTION
## Summary
- document current `GET /observations` lexical scoring semantics in the API contract and README
- order search and topic-search responses by observation `updated_at` descending
- add `updated_at` to search-result payloads and OpenAPI operation docs
- add regression tests for updated-at ordering and OpenAPI documentation

## Verification
- `make test` — 44 passed
- `make lint` — passed
- `git diff --check` — passed

Closes #67
